### PR TITLE
Add URL parameter support for loading JSON files from conversations directory

### DIFF
--- a/conversations/test.json
+++ b/conversations/test.json
@@ -1,0 +1,14 @@
+[
+    {
+        "id": 1,
+        "source": "user",
+        "message": "Hello, this is a test conversation",
+        "timestamp": "2024-03-01T00:00:00.000Z"
+    },
+    {
+        "id": 2,
+        "source": "agent",
+        "message": "Hi! This is a test response",
+        "timestamp": "2024-03-01T00:00:01.000Z"
+    }
+]

--- a/index.html
+++ b/index.html
@@ -365,14 +365,32 @@
             checkbox.addEventListener('change', updateVisibility);
         });
 
-        // Load example.json by default
-        fetch('example.json')
-            .then(response => response.json())
+        // Check URL parameters for file
+        const urlParams = new URLSearchParams(window.location.search);
+        const fileParam = urlParams.get('file');
+        
+        // Load specified file or example.json by default
+        const fileToLoad = fileParam ? `conversations/${fileParam}` : 'example.json';
+        
+        fetch(fileToLoad)
+            .then(response => {
+                if (!response.ok) {
+                    throw new Error(`HTTP error! status: ${response.status}`);
+                }
+                return response.json();
+            })
             .then(conversation => {
                 loadConversation(conversation);
             })
             .catch(error => {
-                console.error('Error loading example.json:', error);
+                console.error(`Error loading ${fileToLoad}:`, error);
+                document.getElementById('timeline').innerHTML = `
+                    <div style="text-align: center; padding: 20px; color: #666;">
+                        <h2>Error Loading Conversation</h2>
+                        <p>${error.message}</p>
+                        <p>Please check the file path and try again.</p>
+                    </div>
+                `;
             });
     </script>
 </body>

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,1 +1,17 @@
 import '@testing-library/jest-dom';
+import { TextEncoder, TextDecoder } from 'util';
+import { jest } from '@jest/globals';
+
+global.TextEncoder = TextEncoder;
+global.TextDecoder = TextDecoder;
+
+// Add fetch polyfill
+global.fetch = jest.fn(() => Promise.resolve({
+  ok: true,
+  json: () => Promise.resolve({})
+}));
+
+// Mock marked library
+global.marked = {
+  parse: jest.fn(text => text)
+};

--- a/tests/url-params.test.js
+++ b/tests/url-params.test.js
@@ -1,0 +1,87 @@
+import fs from 'fs';
+import path from 'path';
+import { JSDOM } from 'jsdom';
+import { fileURLToPath } from 'url';
+import { dirname } from 'path';
+import { jest } from '@jest/globals';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('URL Parameter Tests', () => {
+    let dom;
+    let window;
+    let document;
+    let fetchMock;
+    let consoleErrorMock;
+
+    beforeEach(() => {
+        // Create a new DOM for each test
+        const html = fs.readFileSync(path.resolve(__dirname, '../index.html'), 'utf8');
+        dom = new JSDOM(html, {
+            url: 'http://localhost',
+            runScripts: 'dangerously',
+            resources: 'usable'
+        });
+        window = dom.window;
+        document = window.document;
+
+        // Mock fetch
+        fetchMock = jest.fn(() => Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve({})
+        }));
+        window.fetch = fetchMock;
+
+        // Mock marked
+        window.marked = {
+            parse: jest.fn(text => text)
+        };
+
+        // Mock console.error
+        consoleErrorMock = jest.spyOn(console, 'error').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        consoleErrorMock.mockRestore();
+    });
+
+    async function runScript() {
+        // Get all scripts except external ones
+        const scripts = Array.from(document.querySelectorAll('script:not([src])'));
+        for (const script of scripts) {
+            window.eval(script.textContent);
+        }
+        // Wait for any async operations
+        await new Promise(resolve => setTimeout(resolve, 100));
+    }
+
+    test('loads example.json by default when no URL parameter is present', async () => {
+        await runScript();
+        expect(fetchMock).toHaveBeenCalledWith('example.json');
+    });
+
+    test('loads conversation file from conversations directory when URL parameter is present', async () => {
+        // Set URL parameter
+        delete window.location;
+        window.location = new URL('http://localhost/?file=test.json');
+
+        await runScript();
+        expect(fetchMock).toHaveBeenCalledWith('conversations/test.json');
+    });
+
+    test('displays error message when file loading fails', async () => {
+        // Mock a failed fetch
+        window.fetch = jest.fn(() => Promise.reject(new Error('File not found')));
+
+        // Set URL parameter
+        delete window.location;
+        window.location = new URL('http://localhost/?file=nonexistent.json');
+
+        await runScript();
+
+        const timeline = document.getElementById('timeline');
+        expect(timeline.innerHTML).toContain('Error Loading Conversation');
+        expect(timeline.innerHTML).toContain('File not found');
+    });
+});


### PR DESCRIPTION
This PR adds support for loading JSON files from the conversations directory via URL parameters.

Changes:
- Added URL parameter support to load JSON files from conversations directory
- Added test.json as an example conversation file
- Added tests for URL parameter functionality
- Updated test setup to handle async operations and external dependencies

Example usage:
`https://lyndsysimon.github.io/openhands-conversation-viewer/?file=test.json` will load `conversations/test.json`