### PR TITLE
Add Choose Conversation button

### DIFF
--- a/viewer.html
+++ b/viewer.html
@@ -146,10 +146,19 @@
 </head>
 <body>
     <div class="container">
-        <label class="upload-btn" for="file-input">
-            Upload Conversation JSON
-        </label>
+        <div style="margin-bottom: 20px;">
+            <label class="upload-btn" for="file-input" style="margin-right: 10px;">
+                Upload Conversation JSON
+            </label>
+            <button id="choose-conversation" class="upload-btn">
+                Choose Conversation
+            </button>
+        </div>
         <input type="file" id="file-input" accept=".json">
+        <div id="file-list" class="hidden" style="margin-bottom: 20px; background: white; border: 1px solid #e0e0e0; border-radius: 4px; padding: 10px;">
+            <h3>Available Conversations:</h3>
+            <div id="conversation-files"></div>
+        </div>
         <div id="timeline" class="timeline"></div>
     </div>
 
@@ -306,6 +315,77 @@
             .catch(error => {
                 console.error('Error loading example.json:', error);
             });
+
+        // Function to load conversation from URL
+        function loadConversationFromUrl() {
+            const urlParams = new URLSearchParams(window.location.search);
+            const conversationFile = urlParams.get('conversation');
+            if (conversationFile) {
+                fetch(`conversations/${conversationFile}`)
+                    .then(response => response.json())
+                    .then(conversation => {
+                        loadConversation(conversation);
+                    })
+                    .catch(error => {
+                        console.error('Error loading conversation:', error);
+                    });
+            }
+        }
+
+        // Function to list available conversations
+        function listConversations() {
+            fetch('conversations/')
+                .then(response => response.text())
+                .then(html => {
+                    const parser = new DOMParser();
+                    const doc = parser.parseFromString(html, 'text/html');
+                    const files = Array.from(doc.querySelectorAll('a'))
+                        .filter(a => a.href.endsWith('.json'))
+                        .map(a => a.href.split('/').pop());
+
+                    const filesDiv = document.getElementById('conversation-files');
+                    filesDiv.innerHTML = '';
+                    
+                    files.forEach(file => {
+                        const fileLink = document.createElement('div');
+                        fileLink.style.padding = '8px';
+                        fileLink.style.cursor = 'pointer';
+                        fileLink.style.borderBottom = '1px solid #e0e0e0';
+                        fileLink.textContent = file;
+                        fileLink.addEventListener('mouseover', () => {
+                            fileLink.style.backgroundColor = '#f5f5f5';
+                        });
+                        fileLink.addEventListener('mouseout', () => {
+                            fileLink.style.backgroundColor = 'transparent';
+                        });
+                        fileLink.addEventListener('click', () => {
+                            const newUrl = new URL(window.location.href);
+                            newUrl.searchParams.set('conversation', file);
+                            window.history.pushState({}, '', newUrl);
+                            loadConversationFromUrl();
+                            document.getElementById('file-list').classList.add('hidden');
+                        });
+                        filesDiv.appendChild(fileLink);
+                    });
+                })
+                .catch(error => {
+                    console.error('Error listing conversations:', error);
+                });
+        }
+
+        // Add click handler for the Choose Conversation button
+        document.getElementById('choose-conversation').addEventListener('click', () => {
+            const fileList = document.getElementById('file-list');
+            if (fileList.classList.contains('hidden')) {
+                listConversations();
+                fileList.classList.remove('hidden');
+            } else {
+                fileList.classList.add('hidden');
+            }
+        });
+
+        // Load conversation from URL if specified
+        loadConversationFromUrl();
     </script>
 </body>
 </html>


### PR DESCRIPTION
This PR adds a new "Choose Conversation" button next to the existing "Upload Conversation JSON" button. When clicked, it shows a list of available JSON files from the conversations directory.

Changes:
- Added new "Choose Conversation" button
- Added file list panel that appears when clicking the button
- Added functionality to fetch and display JSON files from conversations directory
- Added functionality to load selected conversations
- Added URL parameter support for direct conversation loading

The URL will update when a conversation is selected (e.g., viewer.html?conversation=terraform.json), making it easy to share links to specific conversations.