### PR TITLE
Fix file listing path and add tests

### DIFF
--- a/conversations.json
+++ b/conversations.json
@@ -1,0 +1,4 @@
+[
+    {"name": "example.json"},
+    {"name": "example2.json"}
+]

--- a/index.html
+++ b/index.html
@@ -404,7 +404,7 @@
 
         // Function to list available conversations
         function listConversations() {
-            fetch('_data/conversations.json')
+            fetch('conversations.json')
                 .then(response => response.json())
                 .then(files => {
                     const filesDiv = document.getElementById('conversation-files');

--- a/test_file_listing.js
+++ b/test_file_listing.js
@@ -1,0 +1,60 @@
+// Test file listing functionality
+describe('File Listing', () => {
+    let fetchMock;
+    let filesDiv;
+
+    beforeEach(() => {
+        // Create a mock DOM environment
+        document.body.innerHTML = `
+            <div id="conversation-files"></div>
+            <div id="file-list" class="hidden"></div>
+        `;
+        filesDiv = document.getElementById('conversation-files');
+
+        // Mock fetch API
+        fetchMock = jest.fn(() =>
+            Promise.resolve({
+                json: () => Promise.resolve([
+                    { name: 'test1.json' },
+                    { name: 'test2.json' }
+                ])
+            })
+        );
+        global.fetch = fetchMock;
+    });
+
+    afterEach(() => {
+        jest.resetAllMocks();
+    });
+
+    test('listConversations fetches from correct path', async () => {
+        await listConversations();
+        expect(fetchMock).toHaveBeenCalledWith('conversations.json');
+    });
+
+    test('listConversations displays files correctly', async () => {
+        await listConversations();
+        const fileLinks = filesDiv.querySelectorAll('div');
+        expect(fileLinks.length).toBe(2);
+        expect(fileLinks[0].textContent).toBe('test1.json');
+        expect(fileLinks[1].textContent).toBe('test2.json');
+    });
+
+    test('clicking file updates URL and hides file list', async () => {
+        await listConversations();
+        const fileLinks = filesDiv.querySelectorAll('div');
+        
+        // Mock window.history and URL
+        const pushStateSpy = jest.spyOn(window.history, 'pushState');
+        global.URL = jest.fn(() => ({
+            searchParams: {
+                set: jest.fn()
+            }
+        }));
+
+        fileLinks[0].click();
+        
+        expect(pushStateSpy).toHaveBeenCalled();
+        expect(document.getElementById('file-list').classList.contains('hidden')).toBe(true);
+    });
+});

--- a/test_setup.js
+++ b/test_setup.js
@@ -1,0 +1,2 @@
+// Make listConversations function available globally for tests
+global.listConversations = window.listConversations;


### PR DESCRIPTION
This PR fixes the file listing functionality and adds tests:

- Move conversations.json to root directory for better accessibility
- Add Jest tests for file listing functionality
- Add test setup file
- Buttons already have consistent styling with upload-btn class

The buttons for "Choose Conversation" and "Upload Conversation JSON" already use the same `upload-btn` class, which provides consistent styling.