### PR TITLE
Add dynamic conversations.json generation

### DIFF
--- a/_plugins/generate_conversations_json.rb
+++ b/_plugins/generate_conversations_json.rb
@@ -1,0 +1,16 @@
+require 'json'
+
+Jekyll::Hooks.register :site, :post_write do |site|
+  # Get all JSON files from the conversations directory
+  conversation_files = Dir.glob(File.join(site.source, 'conversations', '*.json'))
+  
+  # Create array of conversation objects
+  conversations = conversation_files.map do |file|
+    {
+      "name" => File.basename(file)
+    }
+  end
+
+  # Write the conversations.json file
+  File.write(File.join(site.dest, 'conversations.json'), JSON.pretty_generate(conversations))
+end


### PR DESCRIPTION
This PR adds a Jekyll plugin that dynamically generates the conversations.json file during the build process. The file will now automatically include all JSON files from the conversations directory.

Changes:
- Added a Jekyll plugin that scans the conversations directory
- Plugin generates conversations.json during site build
- conversations.json will now reflect all available conversation files

This fixes the issue where the conversations.json file was hardcoded with example entries.